### PR TITLE
Function deduplication

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,15 @@
+v2.1.0
+- adds function deduplication checking
+- fixes file deduplication checking
+
+v2.0.0
+- refactors script as a library of several files that get compiled into the script at the root of the directory
+- adds tests
+- adds file deduplication checking
+- adds multiline import syntax
+
+
+v1.0.0
+- added file transclusion using import X syntax
+- support for multiple files imported ie: import X Y Z
+- import A from X syntax

--- a/lib/file_processing.bsc
+++ b/lib/file_processing.bsc
@@ -141,13 +141,13 @@ process_file() {
             local import_files_list_without_duplicates=()
             # only check file duplicates if the import is the entire file
             if [[ "${import_keywords_list[0]}" == "*" ]]; then
-                for i in ${import_files_list[@]}; do
-                    local full_path=$(readlink -f $i)
+                for j in ${import_files_list[@]}; do
+                    local full_path=$(readlink -f $j)
                     if [[ "${full_path_cache[@]}" != *"$full_path"* ]]; then
                         # this is a file that has not been imported before
                         # so add it to the cache, to prevent it from
                         # being imported again in the future
-                        import_files_list_without_duplicates+=("$i")
+                        import_files_list_without_duplicates+=("$j")
                         full_path_cache+=("$full_path")
                     fi
                 done

--- a/lib/file_processing.bsc
+++ b/lib/file_processing.bsc
@@ -93,10 +93,33 @@ strip_unused_functions() {
     done
 }
 
+# args: $1 the full path of the file being checked.
+# If the full path exists in the full path cache, return true.
+file_has_been_imported() {
+    for file_name in "${full_path_cache[@]}"; do
+        if [[ $1 == $file_name ]]; then
+            # file has been imported already:
+            return 0
+        fi
+    done
+    # file has not been imported yet:
+    return 1
+}
+
 # a variable of absolute paths to files that
 # have been imported. before importing a file
 # check if its full path exists here.
 full_path_cache=()
+
+# a variable of function names that have been imported as
+# import A from X. This variable does not contain
+# function names that are imported as import X, because
+# when we import an entire file, we don't source/evaluate
+# what is in the file. so therefore something like:
+# import A from X
+# import X
+# will contain multiple functions A.
+function_name_cache=()
 
 process_file() {
     local file_data=()
@@ -136,14 +159,14 @@ process_file() {
             local import_files_list=()
             local import_keywords_list=()
             parse_import_statement file_data $i import_files_list import_keywords_list 
-            # TODO:
-            # implement duplicate keyword checking
             local import_files_list_without_duplicates=()
+            local import_keywords_list_without_duplicates=()
+
             # only check file duplicates if the import is the entire file
             if [[ "${import_keywords_list[0]}" == "*" ]]; then
                 for j in ${import_files_list[@]}; do
                     local full_path=$(readlink -f $j)
-                    if [[ "${full_path_cache[@]}" != *"$full_path"* ]]; then
+                    if ! file_has_been_imported "$full_path"; then
                         # this is a file that has not been imported before
                         # so add it to the cache, to prevent it from
                         # being imported again in the future
@@ -152,10 +175,40 @@ process_file() {
                     fi
                 done
             else
-                import_files_list_without_duplicates=("${import_files_list[@]}")
+                # in the event that import keywords list is not everything: "*"
+                # then the import files list should just be a single file
+                # ie: "import A from X", you cannot have "import A from X Y"
+
+                # first: theres no need to import any keyword
+                # if the file has been imported already entirely
+                # so check for that:
+                local full_path=$(readlink -f ${import_files_list[0]})
+                if ! file_has_been_imported "$full_path"; then
+                    import_files_list_without_duplicates=("${import_files_list[@]}")
+                    # check for keyword duplicates by iterating over
+                    # the keywords that we are importing:
+                    for j in ${import_keywords_list[@]}; do
+                        if [[ ${#function_name_cache[@]} -eq 0 ]]; then
+                            # cache is empty, so of course we import j:
+                            import_keywords_list_without_duplicates+=("$j")
+                            function_name_cache+=("$j")
+                        else
+                            # cache is not empty, check if the import keyword j
+                            # exists in the function name cache. if it does
+                            # not exist, import it, and add it to the cache
+                            for k in ${function_name_cache[@]}; do
+                                if [[ $j != $k ]]; then
+                                    import_keywords_list_without_duplicates+=("$j")
+                                    function_name_cache+=("$j")
+                                fi
+                            done
+                        fi
+                    done
+                fi
             fi
 
-            # if we removed all duplicates, and the remaining list
+            # if we removed all duplicate import files
+            # and the remaining list
             # is empty, skip this import
             if [[ ${#import_files_list_without_duplicates[@]} -eq 0 ]]; then
                 continue
@@ -175,8 +228,8 @@ process_file() {
             fi
             if [[ ${import_keywords_list[0]} == "*" ]]; then
                 process_file "$the_actual_script"
-            else
-                local stripped_script=$(strip_unused_functions "$the_actual_script" "${import_keywords_list[@]}")
+            elif [[ ${#import_keywords_list_without_duplicates[@]} != "0" ]]; then
+                local stripped_script=$(strip_unused_functions "$the_actual_script" "${import_keywords_list_without_duplicates[@]}")
                 process_file "$stripped_script"
             fi
 

--- a/lib/file_processing.bsc
+++ b/lib/file_processing.bsc
@@ -139,16 +139,21 @@ process_file() {
             # TODO:
             # implement duplicate keyword checking
             local import_files_list_without_duplicates=()
-            for i in ${import_files_list[@]}; do
-                local full_path=$(readlink -f $i)
-                if [[ "${full_path_cache[@]}" != *"$full_path"* ]]; then
-                    # this is a file that has not been imported before
-                    # so add it to the cache, to prevent it from
-                    # being imported again in the future
-                    import_files_list_without_duplicates+=("$i")
-                    full_path_cache+=("$full_path")
-                fi
-            done
+            # only check file duplicates if the import is the entire file
+            if [[ "${import_keywords_list[0]}" == "*" ]]; then
+                for i in ${import_files_list[@]}; do
+                    local full_path=$(readlink -f $i)
+                    if [[ "${full_path_cache[@]}" != *"$full_path"* ]]; then
+                        # this is a file that has not been imported before
+                        # so add it to the cache, to prevent it from
+                        # being imported again in the future
+                        import_files_list_without_duplicates+=("$i")
+                        full_path_cache+=("$full_path")
+                    fi
+                done
+            else
+                import_files_list_without_duplicates=("${import_files_list[@]}")
+            fi
 
             # if we removed all duplicates, and the remaining list
             # is empty, skip this import

--- a/lib/import_syntax.bsc
+++ b/lib/import_syntax.bsc
@@ -47,7 +47,6 @@ parse_import_statement() {
     ]]; then
         # has a from statement, but its a one line import:
         # import A [...B] from X
-        echo "import string: $actual_import_string"
         local keywords="${actual_import_string%from*}"
         # remove everything before the from keyword:
         local remove_from="from\ "

--- a/source_combine.sh
+++ b/source_combine.sh
@@ -367,10 +367,33 @@ strip_unused_functions() {
     done
 }
 
+# args: $1 the full path of the file being checked.
+# If the full path exists in the full path cache, return true.
+file_has_been_imported() {
+    for file_name in "${full_path_cache[@]}"; do
+        if [[ $1 == $file_name ]]; then
+            # file has been imported already:
+            return 0
+        fi
+    done
+    # file has not been imported yet:
+    return 1
+}
+
 # a variable of absolute paths to files that
 # have been imported. before importing a file
 # check if its full path exists here.
 full_path_cache=()
+
+# a variable of function names that have been imported as
+# import A from X. This variable does not contain
+# function names that are imported as import X, because
+# when we import an entire file, we don't source/evaluate
+# what is in the file. so therefore something like:
+# import A from X
+# import X
+# will contain multiple functions A.
+function_name_cache=()
 
 process_file() {
     local file_data=()
@@ -410,21 +433,56 @@ process_file() {
             local import_files_list=()
             local import_keywords_list=()
             parse_import_statement file_data $i import_files_list import_keywords_list 
-            # TODO:
-            # implement duplicate keyword checking
             local import_files_list_without_duplicates=()
-            for i in ${import_files_list[@]}; do
-                local full_path=$(readlink -f $i)
-                if [[ "${full_path_cache[@]}" != *"$full_path"* ]]; then
-                    # this is a file that has not been imported before
-                    # so add it to the cache, to prevent it from
-                    # being imported again in the future
-                    import_files_list_without_duplicates+=("$i")
-                    full_path_cache+=("$full_path")
-                fi
-            done
+            local import_keywords_list_without_duplicates=()
 
-            # if we removed all duplicates, and the remaining list
+            # only check file duplicates if the import is the entire file
+            if [[ "${import_keywords_list[0]}" == "*" ]]; then
+                for j in ${import_files_list[@]}; do
+                    local full_path=$(readlink -f $j)
+                    if ! file_has_been_imported "$full_path"; then
+                        # this is a file that has not been imported before
+                        # so add it to the cache, to prevent it from
+                        # being imported again in the future
+                        import_files_list_without_duplicates+=("$j")
+                        full_path_cache+=("$full_path")
+                    fi
+                done
+            else
+                # in the event that import keywords list is not everything: "*"
+                # then the import files list should just be a single file
+                # ie: "import A from X", you cannot have "import A from X Y"
+
+                # first: theres no need to import any keyword
+                # if the file has been imported already entirely
+                # so check for that:
+                local full_path=$(readlink -f ${import_files_list[0]})
+                if ! file_has_been_imported "$full_path"; then
+                    import_files_list_without_duplicates=("${import_files_list[@]}")
+                    # check for keyword duplicates by iterating over
+                    # the keywords that we are importing:
+                    for j in ${import_keywords_list[@]}; do
+                        if [[ ${#function_name_cache[@]} -eq 0 ]]; then
+                            # cache is empty, so of course we import j:
+                            import_keywords_list_without_duplicates+=("$j")
+                            function_name_cache+=("$j")
+                        else
+                            # cache is not empty, check if the import keyword j
+                            # exists in the function name cache. if it does
+                            # not exist, import it, and add it to the cache
+                            for k in ${function_name_cache[@]}; do
+                                if [[ $j != $k ]]; then
+                                    import_keywords_list_without_duplicates+=("$j")
+                                    function_name_cache+=("$j")
+                                fi
+                            done
+                        fi
+                    done
+                fi
+            fi
+
+            # if we removed all duplicate import files
+            # and the remaining list
             # is empty, skip this import
             if [[ ${#import_files_list_without_duplicates[@]} -eq 0 ]]; then
                 continue
@@ -444,8 +502,8 @@ process_file() {
             fi
             if [[ ${import_keywords_list[0]} == "*" ]]; then
                 process_file "$the_actual_script"
-            else
-                local stripped_script=$(strip_unused_functions "$the_actual_script" "${import_keywords_list[@]}")
+            elif [[ ${#import_keywords_list_without_duplicates[@]} != "0" ]]; then
+                local stripped_script=$(strip_unused_functions "$the_actual_script" "${import_keywords_list_without_duplicates[@]}")
                 process_file "$stripped_script"
             fi
 
@@ -512,7 +570,6 @@ parse_import_statement() {
     ]]; then
         # has a from statement, but its a one line import:
         # import A [...B] from X
-        echo "import string: $actual_import_string"
         local keywords="${actual_import_string%from*}"
         # remove everything before the from keyword:
         local remove_from="from\ "

--- a/test/duplicate_checking.bats
+++ b/test/duplicate_checking.bats
@@ -35,15 +35,34 @@ function teardown() {
     [[ $number_of_occurences -eq 1 ]]
 }
 
-# TODO: implement this feature
-# @test "duplicate function checking works" {
-#     # assumes bats tmpdir is: /tmp
-#     echo -e "$duplicate_contents" > $BATS_TMPDIR/duplicate.sh
-#     echo -e "import should_only from ./duplicate.sh\n$some_other_contents" > $BATS_TMPDIR/some_other_file.sh
-#     echo -e "import ./some_other_file.sh\nimport should_only from ./duplicate.sh\n$some_contents" > $BATS_TMPDIR/some_file.sh
-#     some_file="$BATS_TMPDIR/some_file.sh"
-#     run $source_combine $some_file
-#     echo "$output"
-#     number_of_occurences=$(grep -o 'should_o nly' <<< "$output" | wc -l)
-#     [[ $number_of_occurences -eq 1 ]]
-# }
+# a simple check if
+# we imported something called A
+# already, then dont import A again
+# if import A from X shows up again somewhere
+@test "duplicate function checking works" {
+    echo -e "$duplicate_contents" > $BATS_TMPDIR/duplicate.sh
+    echo -e "import should_only from ./duplicate.sh\n$some_other_contents" > $BATS_TMPDIR/some_other_file.sh
+    echo -e "import ./some_other_file.sh\nimport should_only from ./duplicate.sh\n$some_contents" > $BATS_TMPDIR/some_file.sh
+    some_file="$BATS_TMPDIR/some_file.sh"
+    run $source_combine $some_file
+    echo "$output"
+    number_of_occurences=$(grep -o 'should_only' <<< "$output" | wc -l)
+    [[ $number_of_occurences -eq 1 ]]
+}
+
+# if you have:
+# import X
+# and later you have:
+# import A from X
+# we should not import A because
+# the entirety of X was already imported
+@test "dupl func check works for importAfromX before importX" {
+    echo -e "$duplicate_contents" > $BATS_TMPDIR/duplicate.sh
+    echo -e "import should_only from ./duplicate.sh\n$some_other_contents" > $BATS_TMPDIR/some_other_file.sh
+    echo -e "import ./duplicate.sh\nimport ./some_other_file.sh\n$some_contents" > $BATS_TMPDIR/some_file.sh
+    some_file="$BATS_TMPDIR/some_file.sh"
+    run $source_combine $some_file
+    echo "$output"
+    number_of_occurences=$(grep -o 'should_only' <<< "$output" | wc -l)
+    [[ $number_of_occurences -eq 1 ]]
+}

--- a/test/duplicate_checking.bats
+++ b/test/duplicate_checking.bats
@@ -3,7 +3,7 @@ function setup() {
     cd $BATS_TEST_DIRNAME
     some_contents="my_var=hello"
     some_other_contents="other_var=yeswoohoo"
-    duplicate_contents="should_only=exist_once"
+    duplicate_contents="should_only() {\necho 'exist once'\n}\n"
     some_dir="$BATS_TMPDIR/some_temp_dir"
     some_file="$BATS_TMPDIR/some_file.sh"
     duplicate_file="$BATS_TMPDIR/duplicate.sh"
@@ -12,7 +12,7 @@ function setup() {
 
     # some_other_file imports duplicate
     # some_file imports some_other_file and duplicate
-    echo "$duplicate_contents" > $BATS_TMPDIR/duplicate.sh
+    echo -e "$duplicate_contents" > $BATS_TMPDIR/duplicate.sh
     echo -e "import ./duplicate.sh\n$some_other_contents" > $BATS_TMPDIR/some_other_file.sh
     echo -e "import ./some_other_file.sh ./duplicate.sh\n$some_contents" > $BATS_TMPDIR/some_file.sh
 }
@@ -31,12 +31,19 @@ function teardown() {
     some_file="$BATS_TMPDIR/some_file.sh"
     run $source_combine $some_file
     echo "$output"
-
-# the "duplicate" import contents should only appear once:
-expected_output="#!/usr/bin/env bash
-$some_other_contents
-$duplicate_contents
-$some_contents"
-
-    [[ $output == "$expected_output" ]]
+    number_of_occurences=$(grep -o 'should_only' <<< "$output" | wc -l)
+    [[ $number_of_occurences -eq 1 ]]
 }
+
+# TODO: implement this feature
+# @test "duplicate function checking works" {
+#     # assumes bats tmpdir is: /tmp
+#     echo -e "$duplicate_contents" > $BATS_TMPDIR/duplicate.sh
+#     echo -e "import should_only from ./duplicate.sh\n$some_other_contents" > $BATS_TMPDIR/some_other_file.sh
+#     echo -e "import ./some_other_file.sh\nimport should_only from ./duplicate.sh\n$some_contents" > $BATS_TMPDIR/some_file.sh
+#     some_file="$BATS_TMPDIR/some_file.sh"
+#     run $source_combine $some_file
+#     echo "$output"
+#     number_of_occurences=$(grep -o 'should_o nly' <<< "$output" | wc -l)
+#     [[ $number_of_occurences -eq 1 ]]
+# }


### PR DESCRIPTION
adds function deduplication, eg:

main:
```sh
import A from X
import Y
```

Y:
```sh
import A from X
```

Since `A` was already imported from X, the `import A from X` statement in Y will not import A.

AND:

main:
```sh
import X
import A from X
```

will not import A since the entirety of X was already imported.
